### PR TITLE
Add dedicated Sankey tab with cash‑flow diagram

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
     <link rel="stylesheet" href="css/calendar.css">
     <link rel="stylesheet" href="css/dropdown-fix.css">
     <link rel="stylesheet" href="css/performance-dashboard.css">
+    <link rel="stylesheet" href="css/cash-flow-sankey.css">
 </head>
 
 <body>
@@ -79,6 +80,11 @@
                     aria-label="Performance Dashboard tab">
                     <span class="icon">📊</span>
                     <span>Analytics</span>
+                </button>
+                <button class="tab-btn" data-tab="sankey" id="sankey-tab-btn"
+                    aria-label="Cash Flow Sankey tab">
+                    <span class="icon">🌊</span>
+                    <span>Sankey</span>
                 </button>
                 <button class="tab-btn" data-tab="settings" id="settings-tab-btn"
                     aria-label="Settings tab">
@@ -1011,14 +1017,14 @@
                     </div>
 
                     <!-- Additional Sections -->
-                    <div class="additional-sections">
-                        <!-- Budget Performance -->
-                        <div class="dashboard-section">
-                            <h3 class="section-header">Budget Performance</h3>
-                            <div class="budget-performance" id="budget-performance">
-                                <!-- Budget cards will be dynamically generated -->
-                            </div>
+                <div class="additional-sections">
+                    <!-- Budget Performance -->
+                    <div class="dashboard-section">
+                        <h3 class="section-header">Budget Performance</h3>
+                        <div class="budget-performance" id="budget-performance">
+                            <!-- Budget cards will be dynamically generated -->
                         </div>
+                    </div>
 
                         <!-- Data Quality -->
                         <div class="dashboard-section">
@@ -1037,6 +1043,44 @@
                         </div>
                     </div>
                 </div>
+            </div>
+            <div id="sankey" class="tab-content" role="region" aria-labelledby="sankey-tab-btn">
+                <section class="cash-flow-section">
+                    <div class="cash-flow-header">
+                        <h2 class="cash-flow-title">Cash Flow Diagram</h2>
+                        <div class="cash-flow-controls">
+                            <div class="period-selector">
+                                <button class="period-btn active" data-period="month">Month</button>
+                                <button class="period-btn" data-period="quarter">Quarter</button>
+                                <button class="period-btn" data-period="year">Year</button>
+                            </div>
+                            <div class="cash-flow-actions">
+                                <button class="export-btn" id="export-sankey" aria-label="Export Sankey diagram">
+                                    <span>📤</span> Export
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="sankey-container" id="cash-flow-sankey-container"></div>
+                    <div class="sankey-stats-grid">
+                        <div class="sankey-stat-card">
+                            <div class="sankey-stat-label">Total Income</div>
+                            <div class="sankey-stat-value" id="sankey-total-income" data-sensitive="true">$0.00</div>
+                        </div>
+                        <div class="sankey-stat-card">
+                            <div class="sankey-stat-label">Total Expenses</div>
+                            <div class="sankey-stat-value" id="sankey-total-expenses" data-sensitive="true">$0.00</div>
+                        </div>
+                        <div class="sankey-stat-card">
+                            <div class="sankey-stat-label">Net Savings</div>
+                            <div class="sankey-stat-value" id="sankey-net-savings" data-sensitive="true">$0.00</div>
+                        </div>
+                        <div class="sankey-stat-card">
+                            <div class="sankey-stat-label">Savings Rate</div>
+                            <div class="sankey-stat-value" id="sankey-savings-rate" data-sensitive="true">0%</div>
+                        </div>
+                    </div>
+                </section>
             </div>
         </main>
     </div>

--- a/js/app.js
+++ b/js/app.js
@@ -27,6 +27,7 @@ import { calendar } from './modules/calendar.js';
 import { eventManager } from './modules/eventManager.js';
 import { populateAllCategoryDropdowns } from './modules/categories.js';
 import { performanceDashboard } from './modules/performanceDashboard.js';
+import { cashFlowSankey } from './modules/cashFlowSankey.js';
 
 // Initialize app after auth is ready
 (async function initApp() {
@@ -708,6 +709,8 @@ import { performanceDashboard } from './modules/performanceDashboard.js';
                     window.updateDebtCharts(appState);
                 } else if (activeTabId === 'investments' && window.lastInvestmentData && window.lastInvestmentChartType) {
                     window.updateInvestmentCharts(window.lastInvestmentData, window.lastInvestmentChartType);
+                } else if (activeTabId === 'sankey' && window.cashFlowSankey) {
+                    window.cashFlowSankey.togglePrivacy();
                 }
             }, 250); // Chart refresh delay - kept at 250ms for stability
         });
@@ -803,6 +806,11 @@ import { performanceDashboard } from './modules/performanceDashboard.js';
                 case 'recurring':
                     const recurringList = document.getElementById("all-recurring-bills-list");
                     if (recurringList) Recurring.renderRecurringBills(state);
+                    break;
+                case 'sankey':
+                    if (window.cashFlowSankey) {
+                        window.cashFlowSankey.init();
+                    }
                     break;
                 case 'rules':
                     // Rules UI manages its own rendering

--- a/js/modules/ui.js
+++ b/js/modules/ui.js
@@ -128,6 +128,34 @@ export function switchTab(tabName, appState) {
     } catch (error) {
       debug.error('Failed to initialize performance dashboard:', error);
     }
+  } else if (tabName === 'sankey') {
+    try {
+      import('./cashFlowSankey.js')
+        .then(module => {
+          if (module.cashFlowSankey) {
+            window.cashFlowSankey = module.cashFlowSankey;
+            module.cashFlowSankey.init();
+
+            const periodButtons = document.querySelectorAll('.period-btn');
+            periodButtons.forEach(btn => {
+              btn.addEventListener('click', () => {
+                periodButtons.forEach(b => b.classList.toggle('active', b === btn));
+                module.cashFlowSankey.setPeriod(btn.dataset.period);
+              });
+            });
+
+            const exportBtn = document.getElementById('export-sankey');
+            if (exportBtn) {
+              exportBtn.addEventListener('click', () => module.cashFlowSankey.exportDiagram());
+            }
+          }
+        })
+        .catch(error => {
+          debug.error('Failed to load cash flow sankey module:', error);
+        });
+    } catch (error) {
+      debug.error('Failed to initialize cash flow sankey:', error);
+    }
   } else if (tabName === 'settings') {
     // Initialize privacy settings when switching to settings tab
     import('./privacySettings.js')


### PR DESCRIPTION
## Summary
- include Sankey styles in HTML
- add a "Sankey" navigation tab
- provide new tab content for the cash‑flow Sankey diagram
- load and update the Sankey diagram when the tab is opened
- refresh the diagram when privacy mode changes or data updates

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68892f3b731c8329b4a27eb76f3c2714