### PR TITLE
Fix icon alignment in transactions mobile view

### DIFF
--- a/css/styles-redesign.css
+++ b/css/styles-redesign.css
@@ -1955,6 +1955,10 @@ tr:hover td {
   color: #e2e8f0;
 }
 
+.table-row.compact {
+  grid-template-columns: auto 1fr;
+}
+
 .table-row:hover {
   background: var(--glass-hover);
 }
@@ -1975,6 +1979,11 @@ tr:hover td {
   justify-content: center;
   font-size: var(--font-size-lg);
   flex-shrink: 0;
+}
+
+.table-icon.small {
+  width: 32px;
+  height: 32px;
 }
 
 .table-icon.income {
@@ -2074,14 +2083,26 @@ tr:hover td {
   
   .table-row {
     grid-template-columns: 1fr;
-    gap: var(--space-2);
-    padding: var(--space-4);
+    gap: calc(var(--space-2) * 0.7);
+    padding: calc(var(--space-4) * 0.7);
   }
   
   .table-row > div {
     display: flex;
     justify-content: space-between;
     align-items: center;
+  }
+
+  .table-row > .table-transaction {
+    display: grid;
+    grid-template-columns: 32px 1fr;
+    gap: calc(var(--space-3) * 0.7);
+    align-items: center;
+  }
+
+  .table-row > .table-transaction .table-icon {
+    width: 32px;
+    height: 32px;
   }
   
   .table-row > div:before {


### PR DESCRIPTION
## Summary
- use a grid layout for transaction cells on small screens
- keep table icons a fixed width to align rows
- tighten row spacing on mobile so more transactions fit on screen

## Testing
- `npm run format`
- `npm run lint` *(with warnings)*
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_688a723ed9348329a5eda05b6086a527